### PR TITLE
refactor: use native css for globals

### DIFF
--- a/src/app.st.css
+++ b/src/app.st.css
@@ -1,3 +1,4 @@
+@st-import './globals.css';
 @st-import Header from './header.st.css';
 
 .root {}

--- a/src/globals.css
+++ b/src/globals.css
@@ -1,16 +1,16 @@
-:global(*),
-:global(::before),
-:global(::after) {
+*,
+::before,
+::after {
   box-sizing: border-box;
 }
 
-:global(html),
-:global(body) {
+html,
+body {
   margin: 0;
   padding: 0;
 }
 
-:global(html) {
+html {
   background-color: rgb(37, 37, 38);
   color: white;
   font-family:
@@ -39,8 +39,8 @@
     "Noto Color Emoji";
 }
 
-:global(a),
-:global(a:visited) {
+a,
+a:visited {
   color: inherit;
   cursor: pointer;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import './globals.st.css';
 import { App } from './app';
 
 createRoot(document.body.appendChild(document.createElement('div'))).render(


### PR DESCRIPTION
Stylable can now import native CSS and use it's global definitions.

This PR Refactor the`globals.st.css` into a native `.css` that doesn't need all the `:global()` wrappers, since native css is global by default, and can be imported by another stylable file.